### PR TITLE
feat: add vercel deployment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,31 @@ Projet Full-stack HETIC en collaboration avec :
   <li><a href="https://github.com/SirMacCready">C. Paul</a></li>
   <li><a href="https://github.com/MOURADAKIL3110">A. Mourad</a></li>
   <li><a href="https://github.com/YohannDCz">D. Yohann</a></li>
-  <li><a href="https://github.com/ValentinMachefaux">M.	Valentin</a></li>
+  <li><a href="https://github.com/ValentinMachefaux">M. Valentin</a></li>
 </ul>
-
 
 Nous vous avons mis un fichier BDD.sql à utiliser sous pgAdmin 4 ou assimilé.
 De plus, voici le shéma de la base de donnée : https://dbdiagram.io/d/6459f1f7dca9fb07c4be90e8
 
 Pour avoir accès à un sample de la page veuillez rentrer dans le navigatuer l'adresse suivante:
-http://localhost:8888/page/page?name=Disney#
+http://localhost:8888/page/page?name=Disney
+
+## Déploiement sur Vercel
+
+Ce projet inclut un fichier `vercel.json` pour faciliter son hébergement sur [Vercel](https://vercel.com/).
+Avant de déployer, définissez les variables d'environnement suivantes dans votre projet Vercel :
+
+- `DB_HOST`
+- `DB_NAME`
+- `DB_USER`
+- `DB_PASSWORD`
+- `DB_PORT`
+
+Après avoir installé l'outil en ligne de commande Vercel, vous pouvez déployer l'application :
+
+```bash
+npm i -g vercel
+vercel
+```
+
+Toutes les requêtes sont routées vers `index.php`, qui charge les différents routeurs de l'application.

--- a/index.php
+++ b/index.php
@@ -5,10 +5,6 @@ ini_set('display_errors', 1);
 // récupérer la méthode et l'URL de la requête
 $method = $_SERVER['REQUEST_METHOD'];
 $url = $_SERVER['REQUEST_URI'];
-
-//  host
-$host = 'localhost:3000';
-
 // sépare l'url en plusieurs sections pour le routage
 $split_url = explode('/', $url);
 

--- a/src/model/Database.php
+++ b/src/model/Database.php
@@ -4,12 +4,12 @@ class Database {
     
     function getConnection () {
         
-        // variables de connection a la bdd
-        $host = "localhost";
-        $dbname = "socialNetwork";
-        $username = "postgres";
-        $password = "0000";
-        $port = 5432;
+        // variables de connection à la bdd
+        $host = getenv('DB_HOST') ?: 'localhost';
+        $dbname = getenv('DB_NAME') ?: 'socialNetwork';
+        $username = getenv('DB_USER') ?: 'postgres';
+        $password = getenv('DB_PASSWORD') ?: '0000';
+        $port = getenv('DB_PORT') ?: 5432;
 
         $connection = null;
         try {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "functions": {
+    "index.php": {
+      "runtime": "vercel-php@0.7.4",
+      "includeFiles": [
+        "src/**",
+        "template/**",
+        "libraries/**",
+        "style.css"
+      ]
+    }
+  },
+  "routes": [
+    { "src": "/(.*)", "dest": "/index.php" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Vercel config to route all requests through `index.php`
- read database credentials from environment variables
- document how to deploy to Vercel

## Testing
- `php -l index.php`
- `php -l src/model/Database.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc938cd27c8333aff06684e0dcc5b3